### PR TITLE
8 instagram make it work

### DIFF
--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'main'
-      - '8-instagram-make-it-work'
 jobs:
   checkout:
     runs-on: self-hosted

--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -9,8 +9,6 @@ jobs:
   checkout:
     runs-on: self-hosted
     steps:
-      - name: Cleanup
-        run: rmdir '/tmp/github-worker/swamp-parser/swamp-parser/checkout'
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -11,3 +11,5 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          path: ${{github.job}}

--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'main'
+      - '8-instagram-make-it-work'
 jobs:
   checkout:
     runs-on: self-hosted

--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -9,6 +9,8 @@ jobs:
   checkout:
     runs-on: self-hosted
     steps:
+      - name: Cleanup
+        run: rmdir '/tmp/github-worker/swamp-parser/swamp-parser/checkout'
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -11,5 +11,3 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          path: ${{github.job}}

--- a/main.py
+++ b/main.py
@@ -24,6 +24,12 @@ sentry_sdk.init(
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # run on startup
+    global connection_semaphore, push_semaphore
+    connection_semaphore = asyncio.Semaphore(
+        int(os.environ.get("AIOHTTP_SEMAPHORE")),
+    )
+    # semaphore 1 for ingestion of items one by one, so feeds don't really mix with each other
+    push_semaphore = asyncio.Semaphore(1)
     asyncio.create_task(
         ParserLoopWorker.start(),
         name=ParserLoopWorker.name,

--- a/main.py
+++ b/main.py
@@ -24,12 +24,6 @@ sentry_sdk.init(
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # run on startup
-    global connection_semaphore, push_semaphore
-    connection_semaphore = asyncio.Semaphore(
-        int(os.environ.get("AIOHTTP_SEMAPHORE")),
-    )
-    # semaphore 1 for ingestion of items one by one, so feeds don't really mix with each other
-    push_semaphore = asyncio.Semaphore(1)
     asyncio.create_task(
         ParserLoopWorker.start(),
         name=ParserLoopWorker.name,

--- a/main.py
+++ b/main.py
@@ -13,11 +13,11 @@ sentry_sdk.init(
     dsn=os.environ["SENTRY_SDK_DSN"],
     # Set traces_sample_rate to 1.0 to capture 100%
     # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
+    traces_sample_rate=0.1,
     # Set profiles_sample_rate to 1.0 to profile 100%
     # of sampled transactions.
     # We recommend adjusting this value in production.
-    profiles_sample_rate=1.0,
+    profiles_sample_rate=0.1,
 )
 
 

--- a/parsers/parser.py
+++ b/parsers/parser.py
@@ -1,4 +1,3 @@
-import feedparser
 import random
 import ssl
 import string
@@ -6,6 +5,7 @@ import urllib
 from datetime import datetime
 from dateutil import parser, tz  # adding custom timezones
 
+import feedparser
 from sentry_sdk import capture_exception
 
 # import os

--- a/parsers/parser_async.py
+++ b/parsers/parser_async.py
@@ -192,7 +192,7 @@ async def parse_href(href: str, **kwargs: dict):
         )
 
         # receive data
-        response_str = await OtherJsonSource.request(href=href)
+        response_str = await OtherJsonSource.request()
 
         # process data
         results = await OtherJsonSource.parse(response_str=response_str)
@@ -208,7 +208,7 @@ async def parse_href(href: str, **kwargs: dict):
         )
 
         # receive data
-        response_str = await OtherJsonSource.request(href=href)
+        response_str = await OtherJsonSource.request()
 
         # process data
         results = await OtherJsonSource.parse(response_str=response_str)

--- a/parsers/parser_async.py
+++ b/parsers/parser_async.py
@@ -192,12 +192,7 @@ async def parse_href(href: str, **kwargs: dict):
         )
 
         # receive data
-        response_str = await OtherJsonSource.request()
-
-        # process data
-        results = await OtherJsonSource.parse(response_str=response_str)
-        for each in results:
-            each["href"] = f"{ href.replace('/api/v1', '') }/post/{ each['href'] }"
+        results = await OtherJsonSource(href=href).run()
 
     # custom source_2 import
     elif os.environ.get("SOURCE_2_FROM") in href:
@@ -207,13 +202,7 @@ async def parse_href(href: str, **kwargs: dict):
             os.environ.get("SOURCE_2_TO"),
         )
 
-        # receive data
-        response_str = await OtherJsonSource.request()
-
-        # process data
-        results = await OtherJsonSource.parse(response_str=response_str)
-        for each in results:
-            each["href"] = f"{ href.replace('/api/v1', '') }/post/{ each['href'] }"
+        results = await OtherJsonSource(href=href).run()
 
     # default RSS import
     else:

--- a/parsers/source.py
+++ b/parsers/source.py
@@ -30,17 +30,17 @@ class Source:
     async def parse(cls, each):
         raise NotImplementedError("Expected to be implemented in child classes")
 
-    async def request(self, href: str) -> str:
+    async def request(self) -> str:
         # avoiding blocks
         referer_domain = "".join(random.choices(string.ascii_letters, k=16))
         headers = {
             # 'user-agent': feed.UserAgent_random().strip(),
-            "referer": f"https://www.{ referer_domain }.com/?q={ href }"
+            "referer": f"https://www.{ referer_domain }.com/?q={ self.href }"
         }
 
         async with aiohttp.ClientSession() as session:
             async with session.get(
-                href,
+                self.href,
                 headers=headers,
                 verify_ssl=False,
             ) as response:
@@ -60,7 +60,7 @@ class Source:
 
     async def run(self) -> list[Update]:
         # receive data
-        response_str = await self.request(href=self.href)
+        response_str = await self.request()
 
         # process data
         results = await self.parse(response_str=response_str)

--- a/parsers/source_json_other.py
+++ b/parsers/source_json_other.py
@@ -5,11 +5,10 @@ from schemas.update import Update
 class OtherJsonSource(JsonSource):
     datetime_format = "%Y-%m-%dT%H:%M:%S"
 
-    @classmethod
-    def parse(cls, response_str: str) -> list[Update]:
+    async def parse(self, response_str: str) -> list[Update]:
         results = []
 
-        for each in super().parse(response_str=response_str):
+        for each in await super().parse(response_str=response_str):
             datetime_string = each["published"]
             if not datetime_string:
                 datetime_string = each["added"]
@@ -17,7 +16,9 @@ class OtherJsonSource(JsonSource):
             results.append(
                 {
                     "name": each["title"],  # longer alternative: each["content"]
-                    "href": each["id"],
-                    "datetime": cls.strptime(datetime_string),
+                    "href": f"{ self.href.replace('/api/v1', '') }/post/{ each['id'] }",
+                    "datetime": self.strptime(datetime_string),
                 }
             )
+
+        return results

--- a/parsers/source_rss.py
+++ b/parsers/source_rss.py
@@ -1,6 +1,7 @@
-import feedparser
 from datetime import datetime
 from dateutil import parser, tz  # adding custom timezones
+
+import feedparser
 
 from parsers.source import Source
 from schemas.update import Update

--- a/parsers/source_rss_proxigram.py
+++ b/parsers/source_rss_proxigram.py
@@ -68,7 +68,7 @@ class ProxigramRssSource(RssSource):
             # we are caching if data received wasn't empty
             await Cache.set(href=self.href, value=response_str)
 
-        return [x._fix_each() for x in results]
+        return [self._fix_each(x) for x in results]
 
     @staticmethod
     def each_name(each) -> str:

--- a/parsers/source_rss_proxigram.py
+++ b/parsers/source_rss_proxigram.py
@@ -28,6 +28,9 @@ class ProxigramRssSource(RssSource):
         #     # .encode("latin1")
         #     # .decode("utf8")
         # )
+        if "<p>" in each["name"]:
+            print("Empty name, I guess:", each["name"], each["href"])
+            each["name"] = ""
 
         return each
 

--- a/parsers/source_rss_proxigram.py
+++ b/parsers/source_rss_proxigram.py
@@ -76,6 +76,11 @@ class ProxigramRssSource(RssSource):
 
             # process data
             results = await super().parse(response_str=response_str)
+            if not results and attempt == 1:
+                empty = feedparser.parse(response_str)
+                if empty["id"]:
+                    logger.warning(f"Still empty {empty}")
+                    logger.warning(f"    {empty['feed']}")
 
             attempt += 1
 

--- a/parsers/source_rss_proxigram.py
+++ b/parsers/source_rss_proxigram.py
@@ -1,5 +1,4 @@
 import asyncio
-import html
 import logging
 import os
 
@@ -7,6 +6,8 @@ from parsers.source_rss import RssSource
 
 from schemas.update import Update
 from services.cache import Cache
+
+# import html
 
 
 logger = logging.getLogger(__name__)

--- a/parsers/source_rss_proxigram.py
+++ b/parsers/source_rss_proxigram.py
@@ -31,16 +31,16 @@ class ProxigramRssSource(RssSource):
         return href
 
     async def request(self) -> str:
+        if os.environ["ALLOW_CACHE"] == "true":
+            value = await Cache.get(href=self.href)
+            if value is not None:
+                return value
+
         global proxigram_semaphore
         # avoiding connection overwhelming and status code 429
         proxigram_semaphore = asyncio.Semaphore(1)
 
         async with proxigram_semaphore:
-            if os.environ["ALLOW_CACHE"] == "true":
-                value = await Cache.get(href=self.href)
-                if value is not None:
-                    return value
-
             return await super().request()
 
     async def parse(self, response_str: str) -> list[Update]:

--- a/parsers/source_rss_proxigram.py
+++ b/parsers/source_rss_proxigram.py
@@ -47,6 +47,7 @@ class ProxigramRssSource(RssSource):
         if os.environ["ALLOW_CACHE"] == "true":
             value = await Cache.get(href=self.href)
             if value is not None:
+                logger.warning(f"Successful cache retrieval for {self.href}")
                 return value
 
         global proxigram_semaphore

--- a/parsers/source_rss_proxigram.py
+++ b/parsers/source_rss_proxigram.py
@@ -20,7 +20,7 @@ class ProxigramRssSource(RssSource):
             "https://www.instagram.com",
         )
         if "<p>" in each["name"]:
-            # logger.warning("Empty name, I guess:", each["name"], each["href"])
+            # logger.info("Empty name, I guess:", each["name"], each["href"])
             each["name"] = ""
 
         return each
@@ -59,7 +59,7 @@ class ProxigramRssSource(RssSource):
         # we constantly receive empty data
         while not results and attempt < 10:
             await asyncio.sleep(3)
-            logger.warning(
+            logger.info(
                 f"---- ProxigramRssSource.parse({self.href=}, {attempt=}) -> {len(results)=}"
             )
 
@@ -77,7 +77,7 @@ class ProxigramRssSource(RssSource):
             attempt += 1
 
         if results and os.environ["ALLOW_CACHE"] == "true":
-            logger.warning(
+            logger.info(
                 f"---- ProxigramRssSource.parse({self.href=}, {attempt=}) -> {len(results)=}"
             )
             # we are caching if data received wasn't empty

--- a/parsers/source_rss_proxigram.py
+++ b/parsers/source_rss_proxigram.py
@@ -67,7 +67,7 @@ class ProxigramRssSource(RssSource):
         attempt = 1
         # we constantly receive empty data
         while not results and attempt < 10:
-            asyncio.sleep(3)
+            await asyncio.sleep(3)
             logger.warning(f"ProxigramRssSource.parse() {attempt=} {results=}")
 
             # receive data

--- a/parsers/source_rss_proxigram.py
+++ b/parsers/source_rss_proxigram.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import os
 
+import feedparser
 from parsers.source_rss import RssSource
 
 from schemas.update import Update
@@ -83,7 +84,10 @@ class ProxigramRssSource(RssSource):
             await Cache.set(href=self.href, value=response_str)
 
         if not results:
-            logger.warning(f"Still empty {response_str}")
+            empty = feedparser.parse(response_str)
+            logger.warning(f"Still empty {empty}")
+            logger.warning(f"    {empty['feed']}")
+            # logger.warning(f"Still empty {response_str}")
         return [self._fix_each(x) for x in results]
 
     @staticmethod

--- a/parsers/source_rss_proxigram.py
+++ b/parsers/source_rss_proxigram.py
@@ -29,7 +29,7 @@ class ProxigramRssSource(RssSource):
         #     # .decode("utf8")
         # )
         if "<p>" in each["name"]:
-            print("Empty name, I guess:", each["name"], each["href"])
+            logger.warning("Empty name, I guess:", each["name"], each["href"])
             each["name"] = ""
 
         return each

--- a/parsers/source_rss_proxigram.py
+++ b/parsers/source_rss_proxigram.py
@@ -42,7 +42,7 @@ class ProxigramRssSource(RssSource):
         if os.environ["ALLOW_CACHE"] == "true":
             value = await Cache.get(href=self.href)
             if value is not None:
-                logger.warning(f"Successful cache retrieval for {self.href}")
+                # logger.warning(f"Successful cache retrieval for {self.href}")
                 return value
 
         global proxigram_semaphore

--- a/parsers/source_rss_proxigram.py
+++ b/parsers/source_rss_proxigram.py
@@ -57,7 +57,7 @@ class ProxigramRssSource(RssSource):
             logger.warning(f"ProxigramRssSource.parse() {attempt=} {results=}")
 
             # receive data
-            response_str = await self.request(href=self.href)
+            response_str = await self.request()
 
             # process data
             results = await super().parse(response_str=response_str)

--- a/parsers/source_rss_proxigram.py
+++ b/parsers/source_rss_proxigram.py
@@ -59,9 +59,7 @@ class ProxigramRssSource(RssSource):
         # we constantly receive empty data
         while not results and attempt < 10:
             await asyncio.sleep(3)
-            # logger.warning(
-            #     f"---- ProxigramRssSource.parse({self.href=}, {attempt=}) -> {len(results)=}"
-            # )
+            # logger.warning(f"---- ProxigramRssSource.parse({self.href=}, {attempt=}) -> {len(results)=}")
 
             # receive data
             response_str = await self.request()
@@ -77,9 +75,7 @@ class ProxigramRssSource(RssSource):
             attempt += 1
 
         if results and os.environ["ALLOW_CACHE"] == "true":
-            # logger.warning(
-            #     f"---- ProxigramRssSource.parse({self.href=}, {attempt=}) -> {len(results)=}"
-            # )
+            # logger.warning(f"---- ProxigramRssSource.parse({self.href=}, {attempt=}) -> {len(results)=}")
             # we are caching if data received wasn't empty
             await Cache.set(href=self.href, value=response_str)
 

--- a/parsers/source_rss_proxigram.py
+++ b/parsers/source_rss_proxigram.py
@@ -81,9 +81,6 @@ class ProxigramRssSource(RssSource):
             # we are caching if data received wasn't empty
             await Cache.set(href=self.href, value=response_str)
 
-        logger.warning(
-            f"ProxigramRssSource.parse() {attempt=} {len(results)=} {self.href=}"
-        )
         return [self._fix_each(x) for x in results]
 
     @staticmethod

--- a/parsers/source_rss_proxigram.py
+++ b/parsers/source_rss_proxigram.py
@@ -22,8 +22,10 @@ class ProxigramRssSource(RssSource):
         # lots of weird symbols, cleaning it up to proper string
         each["name"] = (
             html.unescape(each["name"])
-            .encode('latin1').decode('unicode-escape')
-            .encode('latin1').decode('utf8')
+            .encode("latin1")
+            .decode("unicode-escape")
+            .encode("latin1")
+            .decode("utf8")
         )
 
         return each

--- a/parsers/source_rss_proxigram.py
+++ b/parsers/source_rss_proxigram.py
@@ -42,7 +42,7 @@ class ProxigramRssSource(RssSource):
         if os.environ["ALLOW_CACHE"] == "true":
             value = await Cache.get(href=self.href)
             if value is not None:
-                # logger.info(f"Successful cache retrieval for {self.href}")
+                logger.warning(f"Successful cache retrieval for {self.href}")
                 return value
 
         global proxigram_semaphore

--- a/parsers/source_rss_proxigram.py
+++ b/parsers/source_rss_proxigram.py
@@ -59,7 +59,9 @@ class ProxigramRssSource(RssSource):
         # we constantly receive empty data
         while not results and attempt < 10:
             await asyncio.sleep(3)
-            # logger.warning(f"---- ProxigramRssSource.parse({self.href=}, {attempt=}) -> {len(results)=}")
+            # logger.warning(
+            #     f"---- ProxigramRssSource.parse({self.href=}, {attempt=}) -> {len(results)=}"
+            # )
 
             # receive data
             response_str = await self.request()
@@ -75,7 +77,9 @@ class ProxigramRssSource(RssSource):
             attempt += 1
 
         if results and os.environ["ALLOW_CACHE"] == "true":
-            # logger.warning(f"---- ProxigramRssSource.parse({self.href=}, {attempt=}) -> {len(results)=}")
+            # logger.warning(
+            #     f"---- ProxigramRssSource.parse({self.href=}, {attempt=}) -> {len(results)=}"
+            # )
             # we are caching if data received wasn't empty
             await Cache.set(href=self.href, value=response_str)
 

--- a/parsers/source_rss_proxigram.py
+++ b/parsers/source_rss_proxigram.py
@@ -81,6 +81,11 @@ class ProxigramRssSource(RssSource):
                 if empty["feed"].get("id", None):
                     # private account or no posts
                     break
+                elif "500" in empty["feed"]["summary"] and "Internal Server Error." in empty["feed"]["summary"]: 
+                    # default error, I guess
+                    # possibly account is non-existant
+                    # sometimes there are some other errors...
+                    continue
                 else:
                     logger.warning(f"Still empty {empty}")
                     logger.warning(f"    {empty['feed']}")

--- a/parsers/source_rss_proxigram.py
+++ b/parsers/source_rss_proxigram.py
@@ -42,7 +42,7 @@ class ProxigramRssSource(RssSource):
         if os.environ["ALLOW_CACHE"] == "true":
             value = await Cache.get(href=self.href)
             if value is not None:
-                logger.warning(f"Successful cache retrieval for {self.href}")
+                # logger.info(f"Successful cache retrieval for {self.href}")
                 return value
 
         global proxigram_semaphore

--- a/parsers/source_rss_proxigram.py
+++ b/parsers/source_rss_proxigram.py
@@ -69,7 +69,7 @@ class ProxigramRssSource(RssSource):
         # we constantly receive empty data
         while not results and attempt < 10:
             await asyncio.sleep(3)
-            logger.warning(f"ProxigramRssSource.parse() {attempt=} {results=}")
+            logger.warning(f"ProxigramRssSource.parse() {attempt=} {len(results)=}")
 
             # receive data
             response_str = await self.request()
@@ -80,6 +80,7 @@ class ProxigramRssSource(RssSource):
             attempt += 1
 
         if results and os.environ["ALLOW_CACHE"] == "true":
+            logger.warning(f"ProxigramRssSource.parse() {attempt=} {len(results)=}")
             # we are caching if data received wasn't empty
             await Cache.set(href=self.href, value=response_str)
 

--- a/parsers/source_rss_proxigram.py
+++ b/parsers/source_rss_proxigram.py
@@ -30,18 +30,18 @@ class ProxigramRssSource(RssSource):
 
         return href
 
-    async def request(self, href: str) -> str:
+    async def request(self) -> str:
         global proxigram_semaphore
         # avoiding connection overwhelming and status code 429
         proxigram_semaphore = asyncio.Semaphore(1)
 
         async with proxigram_semaphore:
             if os.environ["ALLOW_CACHE"] == "true":
-                value = await Cache.get()
+                value = await Cache.get(href=self.href)
                 if value is not None:
                     return value
 
-            return await super().request(href)
+            return await super().request()
 
     async def parse(self, response_str: str) -> list[Update]:
         results = await super().parse(response_str=response_str)
@@ -62,7 +62,7 @@ class ProxigramRssSource(RssSource):
 
         if results and os.environ["ALLOW_CACHE"] == "true":
             # we are caching if data received wasn't empty
-            await Cache.set(value=response_str)
+            await Cache.set(href=self.href, value=response_str)
 
         return [x._fix_each() for x in results]
 

--- a/parsers/source_rss_proxigram.py
+++ b/parsers/source_rss_proxigram.py
@@ -77,7 +77,7 @@ class ProxigramRssSource(RssSource):
             attempt += 1
 
         if results and os.environ["ALLOW_CACHE"] == "true":
-            logger.warning(f"ProxigramRssSource.parse() {attempt=} {len(results)=} {self.href=} {len(results)=}")
+            logger.warning(f"ProxigramRssSource.parse() {self.href=} {attempt=} {len(results)=}")
             # we are caching if data received wasn't empty
             await Cache.set(href=self.href, value=response_str)
 

--- a/parsers/source_rss_proxigram.py
+++ b/parsers/source_rss_proxigram.py
@@ -30,7 +30,7 @@ class ProxigramRssSource(RssSource):
         #     # .decode("utf8")
         # )
         if "<p>" in each["name"]:
-            logger.warning("Empty name, I guess:", each["name"], each["href"])
+            # logger.warning("Empty name, I guess:", each["name"], each["href"])
             each["name"] = ""
 
         return each

--- a/parsers/source_rss_proxigram.py
+++ b/parsers/source_rss_proxigram.py
@@ -59,7 +59,9 @@ class ProxigramRssSource(RssSource):
         # we constantly receive empty data
         while not results and attempt < 10:
             await asyncio.sleep(3)
-            logger.warning(f"ProxigramRssSource.parse() {attempt=} {len(results)=} {self.href=}")
+            logger.warning(
+                f"ProxigramRssSource.parse() {attempt=} {len(results)=} {self.href=}"
+            )
 
             # receive data
             response_str = await self.request()
@@ -79,7 +81,9 @@ class ProxigramRssSource(RssSource):
             # we are caching if data received wasn't empty
             await Cache.set(href=self.href, value=response_str)
 
-        logger.warning(f"ProxigramRssSource.parse() {attempt=} {len(results)=} {self.href=}")
+        logger.warning(
+            f"ProxigramRssSource.parse() {attempt=} {len(results)=} {self.href=}"
+        )
         return [self._fix_each(x) for x in results]
 
     @staticmethod

--- a/parsers/source_rss_proxigram.py
+++ b/parsers/source_rss_proxigram.py
@@ -78,7 +78,7 @@ class ProxigramRssSource(RssSource):
             results = await super().parse(response_str=response_str)
             if not results and attempt == 1:
                 empty = feedparser.parse(response_str)
-                if empty["id"]:
+                if empty.ge("id", None):
                     logger.warning(f"Still empty {empty}")
                     logger.warning(f"    {empty['feed']}")
 

--- a/parsers/source_rss_proxigram.py
+++ b/parsers/source_rss_proxigram.py
@@ -78,7 +78,10 @@ class ProxigramRssSource(RssSource):
             results = await super().parse(response_str=response_str)
             if not results and attempt == 1:
                 empty = feedparser.parse(response_str)
-                if empty.ge("id", None):
+                if empty["feed"].get("id", None):
+                    # private account or no posts
+                    break
+                else:
                     logger.warning(f"Still empty {empty}")
                     logger.warning(f"    {empty['feed']}")
 

--- a/parsers/source_rss_proxigram.py
+++ b/parsers/source_rss_proxigram.py
@@ -20,13 +20,13 @@ class ProxigramRssSource(RssSource):
             "https://www.instagram.com",
         )
         # lots of weird symbols, cleaning it up to proper string
-        each["name"] = (
-            html.unescape(each["name"])
-            .encode("latin1")
-            .decode("unicode-escape")
-            .encode("latin1")
-            .decode("utf8")
-        )
+        # each["name"] = (
+        #     html.unescape(each["name"])
+        #     # .encode("latin1")
+        #     # .decode("unicode-escape")
+        #     # .encode("latin1")
+        #     # .decode("utf8")
+        # )
 
         return each
 

--- a/parsers/source_rss_proxigram.py
+++ b/parsers/source_rss_proxigram.py
@@ -78,6 +78,8 @@ class ProxigramRssSource(RssSource):
             # we are caching if data received wasn't empty
             await Cache.set(href=self.href, value=response_str)
 
+        if not results:
+            logger.warning(f"Still empty {response_str}")
         return [self._fix_each(x) for x in results]
 
     @staticmethod

--- a/parsers/source_rss_proxigram.py
+++ b/parsers/source_rss_proxigram.py
@@ -1,4 +1,5 @@
 import asyncio
+import html
 import logging
 import os
 
@@ -17,6 +18,12 @@ class ProxigramRssSource(RssSource):
         each["href"] = each["href"].replace(
             "http://127.0.0.1:30019",
             "https://www.instagram.com",
+        )
+        # lots of weird symbols, cleaning it up to proper string
+        each["name"] = (
+            html.unescape(each["name"])
+            .encode('latin1').decode('unicode-escape')
+            .encode('latin1').decode('utf8')
         )
 
         return each

--- a/parsers/source_rss_proxigram.py
+++ b/parsers/source_rss_proxigram.py
@@ -85,12 +85,12 @@ class ProxigramRssSource(RssSource):
                     # default error, I guess
                     # possibly account is non-existant
                     # sometimes there are some other errors...
+                    attempt += 1
                     continue
                 else:
                     logger.warning(f"Still empty {empty}")
                     logger.warning(f"    {empty['feed']}")
-
-            attempt += 1
+                    attempt += 1
 
         if results and os.environ["ALLOW_CACHE"] == "true":
             logger.warning(f"ProxigramRssSource.parse() {attempt=} {len(results)=}")

--- a/parsers/source_rss_proxigram.py
+++ b/parsers/source_rss_proxigram.py
@@ -59,9 +59,9 @@ class ProxigramRssSource(RssSource):
         # we constantly receive empty data
         while not results and attempt < 10:
             await asyncio.sleep(3)
-            logger.warning(
-                f"---- ProxigramRssSource.parse({self.href=}, {attempt=}) -> {len(results)=}"
-            )
+            # logger.warning(
+            #     f"---- ProxigramRssSource.parse({self.href=}, {attempt=}) -> {len(results)=}"
+            # )
 
             # receive data
             response_str = await self.request()
@@ -77,12 +77,15 @@ class ProxigramRssSource(RssSource):
             attempt += 1
 
         if results and os.environ["ALLOW_CACHE"] == "true":
-            logger.warning(
-                f"---- ProxigramRssSource.parse({self.href=}, {attempt=}) -> {len(results)=}"
-            )
+            # logger.warning(
+            #     f"---- ProxigramRssSource.parse({self.href=}, {attempt=}) -> {len(results)=}"
+            # )
             # we are caching if data received wasn't empty
             await Cache.set(href=self.href, value=response_str)
 
+        logger.warning(
+            f"---- ProxigramRssSource.parse({self.href=}, {attempt=}) -> {len(results)=}"
+        )
         return [self._fix_each(x) for x in results]
 
     @staticmethod

--- a/parsers/source_rss_proxigram.py
+++ b/parsers/source_rss_proxigram.py
@@ -77,7 +77,7 @@ class ProxigramRssSource(RssSource):
             attempt += 1
 
         if results and os.environ["ALLOW_CACHE"] == "true":
-            logger.warning(f"ProxigramRssSource.parse() {attempt=} {len(results)=}")
+            logger.warning(f"ProxigramRssSource.parse() {attempt=} {len(results)=} {self.href=} {len(results)=}")
             # we are caching if data received wasn't empty
             await Cache.set(href=self.href, value=response_str)
 

--- a/parsers/source_rss_proxigram.py
+++ b/parsers/source_rss_proxigram.py
@@ -78,7 +78,7 @@ class ProxigramRssSource(RssSource):
 
         if results and os.environ["ALLOW_CACHE"] == "true":
             logger.warning(
-                f"ProxigramRssSource.parse() {self.href=} {attempt=} {len(results)=}"
+                f"ProxigramRssSource.parse({self.href=}, {attempt=}) -> {len(results)=}"
             )
             # we are caching if data received wasn't empty
             await Cache.set(href=self.href, value=response_str)

--- a/parsers/source_rss_proxigram.py
+++ b/parsers/source_rss_proxigram.py
@@ -20,7 +20,7 @@ class ProxigramRssSource(RssSource):
             "https://www.instagram.com",
         )
         if "<p>" in each["name"]:
-            # logger.info("Empty name, I guess:", each["name"], each["href"])
+            # logger.warning("Empty name, I guess:", each["name"], each["href"])
             each["name"] = ""
 
         return each
@@ -59,7 +59,7 @@ class ProxigramRssSource(RssSource):
         # we constantly receive empty data
         while not results and attempt < 10:
             await asyncio.sleep(3)
-            logger.info(
+            logger.warning(
                 f"---- ProxigramRssSource.parse({self.href=}, {attempt=}) -> {len(results)=}"
             )
 
@@ -77,7 +77,7 @@ class ProxigramRssSource(RssSource):
             attempt += 1
 
         if results and os.environ["ALLOW_CACHE"] == "true":
-            logger.info(
+            logger.warning(
                 f"---- ProxigramRssSource.parse({self.href=}, {attempt=}) -> {len(results)=}"
             )
             # we are caching if data received wasn't empty

--- a/parsers/source_rss_proxigram.py
+++ b/parsers/source_rss_proxigram.py
@@ -1,10 +1,14 @@
 import asyncio
+import logging
 import os
 
 from parsers.source_rss import RssSource
 
 from schemas.update import Update
 from services.cache import Cache
+
+
+logger = logging.getLogger(__name__)
 
 
 class ProxigramRssSource(RssSource):
@@ -50,7 +54,7 @@ class ProxigramRssSource(RssSource):
         # we constantly receive empty data
         while not results and attempt < 10:
             asyncio.sleep(3)
-            print(f"ProxigramRssSource.parse() {attempt=} {results=}")
+            logger.warning(f"ProxigramRssSource.parse() {attempt=} {results=}")
 
             # receive data
             response_str = await self.request(href=self.href)

--- a/parsers/source_rss_proxigram.py
+++ b/parsers/source_rss_proxigram.py
@@ -60,7 +60,7 @@ class ProxigramRssSource(RssSource):
         while not results and attempt < 10:
             await asyncio.sleep(3)
             logger.warning(
-                f"ProxigramRssSource.parse() {attempt=} {len(results)=} {self.href=}"
+                f"**** ProxigramRssSource.parse() {attempt=} {len(results)=} {self.href=}"
             )
 
             # receive data
@@ -78,7 +78,7 @@ class ProxigramRssSource(RssSource):
 
         if results and os.environ["ALLOW_CACHE"] == "true":
             logger.warning(
-                f"ProxigramRssSource.parse({self.href=}, {attempt=}) -> {len(results)=}"
+                f"**** ProxigramRssSource.parse({self.href=}, {attempt=}) -> {len(results)=}"
             )
             # we are caching if data received wasn't empty
             await Cache.set(href=self.href, value=response_str)

--- a/parsers/source_rss_proxigram.py
+++ b/parsers/source_rss_proxigram.py
@@ -60,7 +60,7 @@ class ProxigramRssSource(RssSource):
         while not results and attempt < 10:
             await asyncio.sleep(3)
             logger.warning(
-                f"**** ProxigramRssSource.parse() {attempt=} {len(results)=} {self.href=}"
+                f"---- ProxigramRssSource.parse({self.href=}, {attempt=}) -> {len(results)=}"
             )
 
             # receive data
@@ -78,7 +78,7 @@ class ProxigramRssSource(RssSource):
 
         if results and os.environ["ALLOW_CACHE"] == "true":
             logger.warning(
-                f"**** ProxigramRssSource.parse({self.href=}, {attempt=}) -> {len(results)=}"
+                f"---- ProxigramRssSource.parse({self.href=}, {attempt=}) -> {len(results)=}"
             )
             # we are caching if data received wasn't empty
             await Cache.set(href=self.href, value=response_str)

--- a/parsers/source_rss_proxigram.py
+++ b/parsers/source_rss_proxigram.py
@@ -77,7 +77,9 @@ class ProxigramRssSource(RssSource):
             attempt += 1
 
         if results and os.environ["ALLOW_CACHE"] == "true":
-            logger.warning(f"ProxigramRssSource.parse() {self.href=} {attempt=} {len(results)=}")
+            logger.warning(
+                f"ProxigramRssSource.parse() {self.href=} {attempt=} {len(results)=}"
+            )
             # we are caching if data received wasn't empty
             await Cache.set(href=self.href, value=response_str)
 

--- a/parsers/source_soup_sample.py
+++ b/parsers/source_soup_sample.py
@@ -8,7 +8,7 @@ class SampleSoupSource(Source):
 
     @classmethod
     def parse_each(cls, each):
-        return 
+        return
 
     @classmethod
     async def parse(cls, response_str):
@@ -24,6 +24,5 @@ class SampleSoupSource(Source):
                 "href": each.find("a")["href"],
                 "datetime": cls.strptime(each.find("time")["datetime"]),
             }
-            for each
-            in data.find_all("article", attrs={"class": "post-card"})
+            for each in data.find_all("article", attrs={"class": "post-card"})
         ]

--- a/routers/parsers.py
+++ b/routers/parsers.py
@@ -39,12 +39,3 @@ async def parse_async(
     )
 
     return results
-
-
-# curl -X GET "http://127.0.0.1:30015/parse/ingest/?feed_id=5734"
-@router.get("/ingest/", response_class=PrettyJsonResponse)
-async def parse_one(
-    feed_id: int,
-):
-    "Parse one feed by URL and send it to DB"
-    return await runner(feed_ids=[feed_id])

--- a/routers/parsers.py
+++ b/routers/parsers.py
@@ -3,7 +3,6 @@ from fastapi import APIRouter
 from parsers import parser as parser_base
 from parsers import parser_async
 from responses.PrettyJsonResponse import PrettyJsonResponse
-from runner.runner_async import runner
 from schemas.update import Update
 
 

--- a/routers/parsers.py
+++ b/routers/parsers.py
@@ -3,7 +3,7 @@ from fastapi import APIRouter
 from parsers import parser as parser_base
 from parsers import parser_async
 from responses.PrettyJsonResponse import PrettyJsonResponse
-from runner.runner_async import runner_one
+from runner.runner_async import runner
 from schemas.update import Update
 
 
@@ -47,4 +47,4 @@ async def parse_one(
     feed_id: int,
 ):
     "Parse one feed by URL and send it to DB"
-    return await runner_one(feed_id=feed_id)
+    return await runner(feed_ids=[feed_id])

--- a/routers/parsers.py
+++ b/routers/parsers.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter
 from parsers import parser as parser_base
 from parsers import parser_async
 from responses.PrettyJsonResponse import PrettyJsonResponse
+from runner.runner_async import runner_one
 from schemas.update import Update
 
 
@@ -38,3 +39,12 @@ async def parse_async(
     )
 
     return results
+
+
+# curl -X GET "http://127.0.0.1:30015/parse/ingest/?feed_id=5734"
+@router.get("/ingest/", response_class=PrettyJsonResponse)
+async def parse_one(
+    feed_id: int,
+):
+    "Parse one feed by URL and send it to DB"
+    return await runner_one(feed_id=feed_id)

--- a/routers/runners.py
+++ b/routers/runners.py
@@ -12,12 +12,19 @@ router = APIRouter(
 
 # DEPRECATED
 @router.get("/", response_class=PrettyJsonResponse)
-def runner() -> dict:
+def run() -> dict:
     "Parse all feeds."
     return runner_func()
 
 
 @router.get("/async/", response_class=PrettyJsonResponse)
-async def runner_async() -> dict:
+async def run_async() -> dict:
     "Parse multiple feeds. Asynchronously."
     return await runner_async_func()
+
+
+# curl -X GET "http://127.0.0.1:30015/parse/ingest/?feed_id=5734"
+@router.get("/ingest/", response_class=PrettyJsonResponse)
+async def run_by_id(feed_id: int) -> dict:
+    "Parse one feed by URL and send it to DB"
+    return await runner(feed_ids=[feed_id])

--- a/routers/runners.py
+++ b/routers/runners.py
@@ -27,4 +27,4 @@ async def run_async() -> dict:
 @router.get("/ingest/", response_class=PrettyJsonResponse)
 async def run_by_id(feed_id: int) -> dict:
     "Parse one feed by URL and send it to DB"
-    return await runner(feed_ids=[feed_id])
+    return await runner_async_func(feed_ids=[feed_id])

--- a/runner/runner_async.py
+++ b/runner/runner_async.py
@@ -38,7 +38,7 @@ async def task(feed: Feed):
 
 
 async def runner(feed_ids: list[int] = None):
-    logger.info("runner(): Starting...")
+    logger.warning("runner(): Starting...")
     global connection_semaphore, push_semaphore
     connection_semaphore = asyncio.Semaphore(
         int(os.environ.get("AIOHTTP_SEMAPHORE")),
@@ -77,13 +77,13 @@ async def runner(feed_ids: list[int] = None):
 
     # print and return results
     if errors:
-        logger.info(f"runner(): {errors=}")
-    logger.info(f"runner(): {len(feeds)=}, {updates_new=}, {len(errors)=}")
+        logger.warning(f"runner(): {errors=}")
+    logger.warning(f"runner(): {len(feeds)=}, {updates_new=}, {len(errors)=}")
     if updates_new > 0:
         updates_new__gt_zero = list(filter(lambda x: x["updates_new"] > 0, results))
-        logger.info(f"runner(): updates_new>0={updates_new__gt_zero}")
-    logger.info("runner(): Returning...")
-    logger.info("")
+        logger.warning(f"runner(): updates_new>0={updates_new__gt_zero}")
+    logger.warning("runner(): Returning...")
+    logger.warning("")
     return {
         "errors": errors,
         "results": results,

--- a/runner/runner_async.py
+++ b/runner/runner_async.py
@@ -38,7 +38,7 @@ async def task(feed: Feed):
 
 
 async def runner(feed_ids: list[int] = None):
-    logger.warning("runner(): Starting...")
+    logger.info("runner(): Starting...")
     global connection_semaphore, push_semaphore
     connection_semaphore = asyncio.Semaphore(
         int(os.environ.get("AIOHTTP_SEMAPHORE")),

--- a/runner/runner_async.py
+++ b/runner/runner_async.py
@@ -37,18 +37,7 @@ async def task(feed: Feed):
         raise type(e)(f"{feed['href']}: {str(e)}")
 
 
-async def runner_one(feed_id: int):
-    global connection_semaphore, push_semaphore
-    connection_semaphore = asyncio.Semaphore(1)
-    push_semaphore = asyncio.Semaphore(1)
-
-    feed = await Feed.get_feed(feed_id)
-    results = await task(feed=feed)
-
-    return results
-
-
-async def runner():
+async def runner(feed_ids: list[int] = None):
     logger.warning("runner(): Starting...")
     global connection_semaphore, push_semaphore
     connection_semaphore = asyncio.Semaphore(
@@ -58,7 +47,11 @@ async def runner():
     push_semaphore = asyncio.Semaphore(1)
 
     # run coroutines
-    feeds = await Feed.get_feeds()
+    if feed_ids is None:
+        feeds = await Feed.get_feeds()
+    else:
+        feeds = [await Feed.get_feed(x) for x in feed_ids]
+
     coroutines = []
     for feed in feeds:
         coroutines.append(

--- a/runner/runner_async.py
+++ b/runner/runner_async.py
@@ -38,10 +38,6 @@ async def task(feed: Feed):
 
 
 async def runner_one(feed_id: int):
-    global connection_semaphore, push_semaphore
-    connection_semaphore = asyncio.Semaphore(1)
-    push_semaphore = asyncio.Semaphore(1)
-
     feed = await Feed.get_feed(feed_id)
     results = await task(feed=feed)
 
@@ -50,13 +46,6 @@ async def runner_one(feed_id: int):
 
 async def runner():
     logger.warning("runner(): Starting...")
-    global connection_semaphore, push_semaphore
-    connection_semaphore = asyncio.Semaphore(
-        int(os.environ.get("AIOHTTP_SEMAPHORE")),
-    )
-    # semaphore 1 for ingestion of items one by one, so feeds don't really mix with each other
-    push_semaphore = asyncio.Semaphore(1)
-
     # run coroutines
     feeds = await Feed.get_feeds()
     coroutines = []

--- a/runner/runner_async.py
+++ b/runner/runner_async.py
@@ -37,6 +37,16 @@ async def task(feed: Feed):
         raise type(e)(f"{feed['href']}: {str(e)}")
 
 
+async def runner_one(feed_id: int):
+    global connection_semaphore, push_semaphore
+    connection_semaphore = asyncio.Semaphore(1)
+    push_semaphore = asyncio.Semaphore(1)
+
+    feed = await Feed.get_feed(feed_id)
+    results = await task(feed=feed)
+
+    return results
+
 async def runner():
     logger.warning("runner(): Starting...")
     global connection_semaphore, push_semaphore

--- a/runner/runner_async.py
+++ b/runner/runner_async.py
@@ -57,8 +57,9 @@ async def runner():
     push_semaphore = asyncio.Semaphore(1)
 
     # run coroutines
+    feeds = await Feed.get_feeds()
     coroutines = []
-    for feed in await Feed.get_feeds():
+    for feed in feeds:
         coroutines.append(
             asyncio.Task(
                 task(feed),

--- a/runner/runner_async.py
+++ b/runner/runner_async.py
@@ -38,7 +38,7 @@ async def task(feed: Feed):
 
 
 async def runner(feed_ids: list[int] = None):
-    logger.warning("runner(): Starting...")
+    logger.info("runner(): Starting...")
     global connection_semaphore, push_semaphore
     connection_semaphore = asyncio.Semaphore(
         int(os.environ.get("AIOHTTP_SEMAPHORE")),
@@ -77,13 +77,13 @@ async def runner(feed_ids: list[int] = None):
 
     # print and return results
     if errors:
-        logger.warning(f"runner(): {errors=}")
-    logger.warning(f"runner(): {len(feeds)=}, {updates_new=}, {len(errors)=}")
+        logger.info(f"runner(): {errors=}")
+    logger.info(f"runner(): {len(feeds)=}, {updates_new=}, {len(errors)=}")
     if updates_new > 0:
         updates_new__gt_zero = list(filter(lambda x: x["updates_new"] > 0, results))
-        logger.warning(f"runner(): updates_new>0={updates_new__gt_zero}")
-    logger.warning("runner(): Returning...")
-    logger.warning("")
+        logger.info(f"runner(): updates_new>0={updates_new__gt_zero}")
+    logger.info("runner(): Returning...")
+    logger.info("")
     return {
         "errors": errors,
         "results": results,

--- a/runner/runner_async.py
+++ b/runner/runner_async.py
@@ -47,6 +47,7 @@ async def runner_one(feed_id: int):
 
     return results
 
+
 async def runner():
     logger.warning("runner(): Starting...")
     global connection_semaphore, push_semaphore

--- a/runner/runner_async.py
+++ b/runner/runner_async.py
@@ -38,7 +38,7 @@ async def task(feed: Feed):
 
 
 async def runner(feed_ids: list[int] = None):
-    logger.info("runner(): Starting...")
+    logger.warning("runner(): Starting...")
     global connection_semaphore, push_semaphore
     connection_semaphore = asyncio.Semaphore(
         int(os.environ.get("AIOHTTP_SEMAPHORE")),

--- a/runner/runner_async.py
+++ b/runner/runner_async.py
@@ -6,12 +6,13 @@ import aiohttp
 from sentry_sdk import capture_exception
 
 import parsers.parser_async as parser_async
+from schemas.feed import Feed
 
 
 logger = logging.getLogger(__name__)
 
 
-async def task(feed):
+async def task(feed: Feed):
     try:
         async with connection_semaphore:
             updates = []
@@ -47,20 +48,7 @@ async def runner():
 
     # run coroutines
     coroutines = []
-    try:
-        async with aiohttp.ClientSession() as session:
-            async with session.get(
-                f"{ os.environ['SWAMP_API'] }/feeds/?requires_update=true"
-            ) as response:
-                feeds = await response.json()
-    except aiohttp.client_exceptions.ClientConnectorError as e:
-        # seems to be triggered by swamp-api not being up on startup
-        # is not expected to happen in the future
-        capture_exception(e)
-        feeds = []
-        logger.warning(f"ERROR: {e}")
-
-    for feed in feeds:
+    for feed in await Feed.get_feeds():
         coroutines.append(
             asyncio.Task(
                 task(feed),

--- a/schemas/feed.py
+++ b/schemas/feed.py
@@ -40,6 +40,7 @@ class Feed(BaseModel):
                 f"{ os.environ['SWAMP_API'] }/feeds/?requires_update=true"
             ) as response:
                 return [cls.from_full(x) for x in await response.json()]
+        # TODO: remove later if everything is alright
         # except aiohttp.client_exceptions.ClientConnectorError as e:
         #     # seems to be triggered by swamp-api not being up on startup
         #     # is not expected to happen in the future
@@ -55,6 +56,7 @@ class Feed(BaseModel):
                 f"{ os.environ['SWAMP_API'] }/feeds/{ feed_id }"
             ) as response:
                 return cls.from_full(await response.json())
+        # TODO: remove later if everything is alright
         # except aiohttp.client_exceptions.ClientConnectorError as e:
         #     # seems to be triggered by swamp-api not being up on startup
         #     # is not expected to happen in the future

--- a/schemas/feed.py
+++ b/schemas/feed.py
@@ -1,0 +1,48 @@
+import aiohttp
+import os
+from datetime import datetime
+from pydantic import BaseModel
+from typing import Type, Self
+
+
+# unused
+# class FullFeed(BaseModel):
+#     _id: int
+#     _created: datetime
+#     _delayed: datetime
+#     title: str
+#     href: str
+#     href_user: str
+#     private: bool
+#     frequency: str
+#     notes: str
+#     json: dict
+
+
+# feed with unnecessary fields cut off
+class Feed(BaseModel):
+    _id: int
+    title: str  # not REALLY needed
+    href: str
+
+    def from_full(full_feed: dict) -> Self:
+        return {
+            "_id": full_feed["_id"],
+            "href": full_feed["href"],
+            "title": full_feed["title"],
+        }
+
+    @classmethod
+    async def get_feeds(cls) -> list[Self]:
+        # try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                f"{ os.environ['SWAMP_API'] }/feeds/?requires_update=true"
+            ) as response:
+                return [cls.from_full(x) for x in await response.json()]
+        # except aiohttp.client_exceptions.ClientConnectorError as e:
+        #     # seems to be triggered by swamp-api not being up on startup
+        #     # is not expected to happen in the future
+        #     capture_exception(e)
+        #     feeds = []
+        #     logger.error(f"ERROR: {e}")

--- a/schemas/feed.py
+++ b/schemas/feed.py
@@ -1,8 +1,8 @@
 import aiohttp
 import os
-from datetime import datetime
+# from datetime import datetime
 from pydantic import BaseModel
-from typing import Type, Self
+from typing import Self
 
 
 # unused

--- a/schemas/feed.py
+++ b/schemas/feed.py
@@ -1,9 +1,9 @@
 import aiohttp
 import os
-# from datetime import datetime
 from pydantic import BaseModel
 from typing import Self
 
+# from datetime import datetime
 
 # unused
 # class FullFeed(BaseModel):

--- a/schemas/feed.py
+++ b/schemas/feed.py
@@ -46,3 +46,18 @@ class Feed(BaseModel):
         #     capture_exception(e)
         #     feeds = []
         #     logger.error(f"ERROR: {e}")
+
+    @classmethod
+    async def get_feed(cls, feed_id: int) -> Self:
+        # try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                f"{ os.environ['SWAMP_API'] }/feeds/{ feed_id }"
+            ) as response:
+                return cls.from_full(await response.json())
+        # except aiohttp.client_exceptions.ClientConnectorError as e:
+        #     # seems to be triggered by swamp-api not being up on startup
+        #     # is not expected to happen in the future
+        #     capture_exception(e)
+        #     feeds = []
+        #     logger.error(f"ERROR: {e}")

--- a/services/cache.py
+++ b/services/cache.py
@@ -18,7 +18,7 @@ class Cache:
         r = await redis.from_url(os.environ["REDIS"], decode_responses=True)
         async with r.pipeline(transaction=True) as pipe:
             values = await pipe.get(cls.key_from_href(href)).execute()
-            # result is a list
+            # result is a list, but we need only one item
             return values[0]
 
     @classmethod

--- a/services/cache.py
+++ b/services/cache.py
@@ -6,7 +6,7 @@ import redis.asyncio as redis
 
 class Cache:
     @staticmethod
-    def key(href: str) -> str:
+    def key_from_href(href: str) -> str:
         return f"swamp-parser:request:{href}"
 
     @staticmethod
@@ -17,7 +17,7 @@ class Cache:
     async def get(cls, href: str) -> str:
         r = await redis.from_url(os.environ["REDIS"])
         async with r.pipeline(transaction=True) as pipe:
-            values = await pipe.get(cls.key(href)).execute()
+            values = await pipe.get(cls.key_from_href(href)).execute()
             # result is a list
             return values[0]
 
@@ -25,6 +25,6 @@ class Cache:
     async def set(cls, href: str, value: str):
         r = await redis.from_url(os.environ["REDIS"])
         async with r.pipeline(transaction=True) as pipe:
-            await pipe.set(cls.key(href), str(value)).expireat(
-                cls.key(href), cls.timeout()
+            await pipe.set(cls.key_from_href(href), str(value)).expireat(
+                cls.key_from_href(href), cls.timeout()
             ).execute()

--- a/services/cache.py
+++ b/services/cache.py
@@ -25,7 +25,6 @@ class Cache:
     async def set(cls, href: str, value: str):
         r = await redis.from_url(os.environ["REDIS"])
         async with r.pipeline(transaction=True) as pipe:
-            await (
-                pipe.set(cls.key(href), str(value))
-                    .expireat(cls.key(href), cls.timeout())
+            await pipe.set(cls.key(href), str(value)).expireat(
+                cls.key(href), cls.timeout()
             ).execute()

--- a/services/cache.py
+++ b/services/cache.py
@@ -6,22 +6,22 @@ import redis.asyncio as redis
 
 class Cache:
     @staticmethod
-    def url(self):
-        return f"swamp-parser:request:{self.href}"
+    def key(href: str) -> str:
+        return f"swamp-parser:request:{href}"
 
     @staticmethod
-    def timeout():
+    def timeout() -> datetime:
         return datetime.now() + timedelta(days=7)
 
     @classmethod
-    async def get(cls):
+    async def get(cls, href: str) -> str:
         r = await redis.from_url(os.environ["REDIS"])
         async with r.pipeline(transaction=True) as pipe:
-            return await pipe.get(cls.cache_url())
+            return await pipe.get(cls.key(href))
 
     @classmethod
-    async def set(cls, value: str):
+    async def set(cls, href: str, value: str):
         r = await redis.from_url(os.environ["REDIS"])
         async with r.pipeline(transaction=True) as pipe:
-            await pipe.set(cls.cache_url(), value)
-            pipe.expireat(cls.cache_url(), cls.cache_timeout())
+            await pipe.set(cls.key(href), value)
+            pipe.expireat(cls.key(href), cls.cache_timeout())

--- a/services/cache.py
+++ b/services/cache.py
@@ -15,7 +15,7 @@ class Cache:
 
     @classmethod
     async def get(cls, href: str) -> str:
-        r = await redis.from_url(os.environ["REDIS"])
+        r = await redis.from_url(os.environ["REDIS"], decode_responses=True)
         async with r.pipeline(transaction=True) as pipe:
             values = await pipe.get(cls.key_from_href(href)).execute()
             # result is a list
@@ -23,7 +23,7 @@ class Cache:
 
     @classmethod
     async def set(cls, href: str, value: str):
-        r = await redis.from_url(os.environ["REDIS"])
+        r = await redis.from_url(os.environ["REDIS"], decode_responses=True)
         async with r.pipeline(transaction=True) as pipe:
             await pipe.set(cls.key_from_href(href), str(value)).expireat(
                 cls.key_from_href(href), cls.timeout()


### PR DESCRIPTION
- [x] Make Instagram (finally!) work as `ProxigramRssSource`. Backup option is there (commented out) as well
- [x] Refactoring: parser_async reduced
- [x] Refactoring (Source):
    - [x] Refactoring: improved inheritance structure, more self usage and `parse()` is now async
    - [x] `run()` function added
    - [x] RSS migrated to `RssSource` from parser_async
- [x] logging instead of `print()`s
- [x] Redis: we can cache data to Redis now
- [x] Routes: feed ingestion route added
- [x] Refactoring: type hints added to more functions
    - [x] (Shortened) Feed schema created
- [x] Russian manga rss parsers removed
    - [x] Remove them from DB